### PR TITLE
Project wasn't building :(

### DIFF
--- a/azure-mobileservices-net/src/Documents.MobileServices/DocumentDBDomainManager.cs
+++ b/azure-mobileservices-net/src/Documents.MobileServices/DocumentDBDomainManager.cs
@@ -39,7 +39,7 @@ namespace Documents.MobileServices
                 _databaseId = databaseId;
             }
 
-            public DocumentEntityDomainManager(HttpRequestMessage request, ApiServices services)
+            public DocumentDBDomainManager(HttpRequestMessage request, ApiServices services)
             {
                 var attribute = typeof(TDocument).GetCustomAttributes(typeof(DocumentAttribute), true).FirstOrDefault() as DocumentAttribute;
                 if (attribute == null)


### PR DESCRIPTION
Previous update which had changed class from `DocumentEntityDomainManager` to `DocumentDBDomainManager` which might have not have merged correctly?

Constructor (which is used by the todo site) has been corrected.