### PR TITLE
Spillover partition - Create new partition indexes based on last partition number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,3 @@ ehthumbs.db
 
 # Folder config file
 Desktop.ini
-samples/code-samples/DocumentDB.Samples.sln.GhostDoc.xml

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ ehthumbs.db
 
 # Folder config file
 Desktop.ini
+samples/code-samples/DocumentDB.Samples.sln.GhostDoc.xml

--- a/samples/code-samples/Partitioning/Partitioners/SpilloverPartitionResolver.cs
+++ b/samples/code-samples/Partitioning/Partitioners/SpilloverPartitionResolver.cs
@@ -147,19 +147,6 @@
             return collections.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value).ToList();
         }
 
-        /// <summary>
-        /// Create a collection if the list is empty, or if the latest one is getting full.
-        /// </summary>
-        //private void CreateCollectionIfRequired()
-        //{
-        //    if (this.ShouldCreateCollection())
-        //    {
-        //        string collectionId = string.Format("{0}{1}", this.CollectionIdPrefix, this.CollectionLinks.Count);
-        //        var createdCollection = DocumentClientHelper.GetCollectionAsync(this.Client, this.Database, collectionId, this.CollectionTemplate).Result;
-        //        this.CollectionLinks.Add(createdCollection.SelfLink);
-        //    }
-        //}
-
         private void CreateCollectionIfRequired()
         {
             if (this.ShouldCreateCollection())

--- a/samples/code-samples/Partitioning/Partitioners/SpilloverPartitionResolver.cs
+++ b/samples/code-samples/Partitioning/Partitioners/SpilloverPartitionResolver.cs
@@ -78,6 +78,8 @@
         /// </summary>
         public DateTime LastCheckTimeUtc { get; private set; }
 
+        int NextCollectionNumber { get; set; }
+
         /// <summary>
         /// Returns the collections to read for a document. Here we return all collections.
         /// </summary>
@@ -118,7 +120,7 @@
         /// <param name="collectionIdPrefix">The prefix to use while creating collections.</param>
         /// <param name="spec">The specification/template to use to create collections.</param>
         /// <returns>The list of collection self links.</returns>
-        private static List<string> GetCollections(
+        private List<string> GetCollections(
             DocumentClient client,
             Database database,
             string collectionIdPrefix,
@@ -133,7 +135,14 @@
                     collections[collectionNumber] = collection.SelfLink;
                 }
             }
-
+            if (collections.Any())
+            {
+                NextCollectionNumber = collections.Keys.Max() + 1;
+            }
+            else
+            {
+                NextCollectionNumber = 0;
+            }
             // Return selflinks in ID order
             return collections.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value).ToList();
         }
@@ -141,15 +150,34 @@
         /// <summary>
         /// Create a collection if the list is empty, or if the latest one is getting full.
         /// </summary>
+        //private void CreateCollectionIfRequired()
+        //{
+        //    if (this.ShouldCreateCollection())
+        //    {
+        //        string collectionId = string.Format("{0}{1}", this.CollectionIdPrefix, this.CollectionLinks.Count);
+        //        var createdCollection = DocumentClientHelper.GetCollectionAsync(this.Client, this.Database, collectionId, this.CollectionTemplate).Result;
+        //        this.CollectionLinks.Add(createdCollection.SelfLink);
+        //    }
+        //}
+
         private void CreateCollectionIfRequired()
         {
             if (this.ShouldCreateCollection())
             {
-                string collectionId = string.Format("{0}{1}", this.CollectionIdPrefix, this.CollectionLinks.Count);
-                var createdCollection = DocumentClientHelper.GetCollectionAsync(this.Client, this.Database, collectionId, this.CollectionTemplate).Result;
-                this.CollectionLinks.Add(createdCollection.SelfLink);
+                try
+                {
+                    string collectionId = string.Format("{0}{1}", this.CollectionIdPrefix, NextCollectionNumber);
+                    var createdCollection = DocumentClientHelper.GetCollectionAsync(this.Client, this.Database, collectionId, this.CollectionTemplate).Result;
+                    this.CollectionLinks.Add(createdCollection.SelfLink);
+                }
+                catch
+                {
+                    this.CollectionLinks = GetCollections(this.Client, this.Database, this.CollectionIdPrefix,
+                        this.CollectionTemplate);
+                }
             }
         }
+
 
         /// <summary>
         /// Check if a spillover has to be scheduled.


### PR DESCRIPTION
Updated the code to determine the next partition's index based on the number of the last partition (.{0}), rather than number of partitions.

This is to account for scenarios where older partitions may need to be deleted if not needed anymore, for example in the case of logs.

Cheers.