### PR TITLE
Fixes to various samples code

### DIFF
--- a/samples/code-samples/Partitioning/DataModels/UserProfile.cs
+++ b/samples/code-samples/Partitioning/DataModels/UserProfile.cs
@@ -44,7 +44,6 @@
         /// <summary>
         /// Gets or sets the primary region for the user.
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
         public Region PrimaryRegion { get; set; }
 
         /// <summary>
@@ -55,7 +54,6 @@
         /// <summary>
         /// Gets or sets the status of the user.
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
         public UserStatus Status { get; set; }
 
         /// <summary>

--- a/samples/code-samples/Partitioning/Program.cs
+++ b/samples/code-samples/Partitioning/Program.cs
@@ -265,7 +265,7 @@
             UserProfile johnProfile = (UserProfile)(dynamic)latestJohnDocument;
             johnProfile.Status = UserStatus.Busy;
 
-            await this.client.ReplaceDocumentAsync(latestJohnDocument);
+            await this.client.ReplaceDocumentAsync(latestJohnDocument.SelfLink, johnProfile);
 
             // Query for John's document by ID. We can use the PartitionResolver to restrict the query to just the partition containing @John
             // Again the query uses the database self link, and relies on the hash resolver to route the appropriate collection.
@@ -273,11 +273,11 @@
                 .Where(u => u.UserName == "@John");
             johnProfile = query.AsEnumerable().FirstOrDefault();
 
-            // Query for all Available users. Here since there is no partition key, the query is serially executed across each partition/collection. 
-            query = this.client.CreateDocumentQuery<UserProfile>(database.SelfLink).Where(u => u.Status == UserStatus.Available);
-            foreach (UserProfile activeUser in query)
+            // Query for all Busy users. Here since there is no partition key, the query is serially executed across each partition/collection. 
+            query = this.client.CreateDocumentQuery<UserProfile>(database.SelfLink).Where(u => u.Status == UserStatus.Busy);
+            foreach (UserProfile busyUser in query)
             {
-                Console.WriteLine(activeUser);
+                Console.WriteLine(busyUser);
             }
              
             // Find the collections where a document exists in. It's uncommon to do this, but can be useful if for example to execute a 
@@ -295,7 +295,6 @@
         /// <summary>
         /// Illustrate how to load and save the serializer state. Uses HashPartitionResolver as example.
         /// </summary>
-        /// <param name="hashResolver">The HashResolver instance.</param>
         private void RunSerializeDeserializeSample(HashPartitionResolver hashResolver)
         {
             // Store the partition resolver's configuration as JSON.
@@ -315,7 +314,7 @@
         /// Show how to repartition a hash resolver by adding/removing collections.
         /// </summary>
         /// <param name="database">The database to run the samples on.</param>
-        /// <returns>The created HashPartitionResolver.</returns>
+        /// <returns>The Task for the asynchronous execution.</returns>
         private async Task RepartitionDataSample(Database database)
         {
             var manager = new DocumentClientHashPartitioningManager(u => ((UserProfile)(dynamic)u).UserId, this.client, database, 3);

--- a/samples/code-samples/Queries/Program.cs
+++ b/samples/code-samples/Queries/Program.cs
@@ -379,7 +379,7 @@
             // LINQ Lambda
             familiesLinqQuery = client.CreateDocumentQuery<Family>(collectionLink)
                        .Where(f => f.LastName == "Andersen")
-                       .OrderByDescending(f => f.Children[0].Grade);
+                       .OrderByDescending(f => f.Address.State);
 
             Assert("Expected only 1 family", familiesLinqQuery.ToList().Count == 1);
 


### PR DESCRIPTION
As I went through the samples code I discovered a few bugs. This fixes them.

For the `StringEnumConverter` removal, this LINQ query will not work correctly with it:

`query = this.client.CreateDocumentQuery<UserProfile>(database.SelfLink).Where(u => u.Status == UserStatus.Busy)`

it translates to a query with `Status = 1` instead of `Status = 'Busy'`. I would assume this is a bug in the LINQ to query code elsewhere in DocDB.